### PR TITLE
fix(InMemoryFsFile/readable): close when done

### DIFF
--- a/src/memory_file.ts
+++ b/src/memory_file.ts
@@ -189,6 +189,10 @@ export class InMemoryFsFile implements Deno.FsFile {
     return new ReadableStream({
       pull: (controller) => {
         const res = this.#file.buffer.slice(this.#offset);
+        if (res.byteLength === 0) {
+          controller.close();
+          return;
+        }
         this.#offset += res.byteLength;
         controller.enqueue(res);
       },


### PR DESCRIPTION
Ensure closing the stream when there is no more bytes to read.